### PR TITLE
Added codec entry for PGS (Presentation Graphic Stream).

### DIFF
--- a/CodecID.xml
+++ b/CodecID.xml
@@ -426,6 +426,13 @@
     </codec>
 
     <codec>
+        <id>S_HDMV/PGS</id>
+        <name>PGS</name>
+        <desc>Presentation Graphic Stream Subtitle Format</desc>
+        <ext>pgs</ext>
+    </codec>
+
+    <codec>
         <id>S_KATE</id>
         <name>Kate</name>
         <desc>Karaoke And Text Encapsulation</desc>


### PR DESCRIPTION
Missing entry prevented extraction of PGS tracks due to missing CodecExt property.

Signed-off-by: AdZero
