### PR TITLE
Corrected PGS files extension which is "sup" instead of "pgs".

### DIFF
--- a/CodecID.xml
+++ b/CodecID.xml
@@ -429,7 +429,7 @@
         <id>S_HDMV/PGS</id>
         <name>PGS</name>
         <desc>Presentation Graphic Stream Subtitle Format</desc>
-        <ext>pgs</ext>
+        <ext>sup</ext>
     </codec>
 
     <codec>


### PR DESCRIPTION
Signed-off-by: AdZero
